### PR TITLE
Add button to let admins show locked challenges

### DIFF
--- a/src/containers/pages/Campaign.js
+++ b/src/containers/pages/Campaign.js
@@ -8,7 +8,7 @@ import {
     Button, FlexRow, Input, Form, FormError, SBTSection, Section, Link,
     FlashText, Leader, SectionTitle2, Modal, Page
 } from "@ractf/ui-kit";
-import { plugins, apiContext, apiEndpoints, appContext } from "ractf";
+import { plugins, apiContext, apiEndpoints, appContext, localConfig } from "ractf";
 
 import "./Campaign.scss";
 
@@ -110,6 +110,7 @@ const CategoryList = () => {
 
 export default () => {
     const [anc, setAnc] = useState(false);
+    const [showLocked, setShowLocked] = useState(localConfig("prefs.show_locked", undefined, false));
 
     const { t } = useTranslation();
     const { history, location, match } = useReactRouter();
@@ -135,6 +136,11 @@ export default () => {
         };
     };
 
+    const toggleShowLocked = () => {
+        localConfig("prefs.show_locked", !showLocked);
+        setShowLocked(!showLocked);
+    };
+
     if (!api.challenges)
         api.challenges = [];
 
@@ -156,7 +162,7 @@ export default () => {
         </>;
     } else {
         challengeTab = React.createElement(
-            handler.component, { challenges: tab, showEditor: showEditor, isEdit: edit }
+            handler.component, { challenges: tab, showEditor: showEditor, isEdit: edit, showLocked: showLocked }
         );
     }
 
@@ -175,9 +181,15 @@ export default () => {
                     <Button key={"edS"} className={"campEditButton"} to={"#"} warning>
                         {t("edit_stop")}
                     </Button>
-                </> : <Button key={"edE"} className={"campEditButton"} to={"#edit"} warning>
+                </> : <>
+                    <Button key={"toggleShowLocked"} className={"campEditButton"} click={toggleShowLocked}>
+                        {showLocked ? t("admin.hide_locked") : t("admin.show_locked")}
+                    </Button>
+                    <Button key={"edE"} className={"campEditButton"} to={"#edit"} warning>
                         {t("edit")}
-                    </Button>}
+                    </Button>
+                </>
+                }
             </FlexRow>}
             {!api.user.team && <FlashText warning>{t("campaign.no_team")}</FlashText>}
             <div className={"campInner"}>{challengeTab}</div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -124,6 +124,8 @@
     },
     "admin": {
         "import_export": "Import/Export",
+        "show_locked": "Show locked challenges",
+        "hide_locked": "Hide locked challenges",
         "import_and_export": "Import and Export",
         "account_active": "Account Active",
         "account_visible": "Account Visible",

--- a/src/plugins/campaign/setup.js
+++ b/src/plugins/campaign/setup.js
@@ -23,7 +23,7 @@ const emptyChallenge = (x, y) => ({
 });
 
 
-const CampaignChallenges = ({ challenges, showEditor, isEdit }) => {
+const CampaignChallenges = ({ challenges, showEditor, isEdit, showLocked }) => {
     const [reRender, setReRender] = useState(0);
     const endpoints = useContext(apiEndpoints);
 
@@ -100,10 +100,10 @@ const CampaignChallenges = ({ challenges, showEditor, isEdit }) => {
                 linksU = (above && chal.unlocks.indexOf(above.id) !== -1),
                 linksD = (below && chal.unlocks.indexOf(below.id) !== -1);
 
-            let unlocked = isEdit || (chal.unlocked && !chal.hidden) || chal.solved;
+            let unlocked = isEdit || (chal.unlocked && !chal.hidden) || chal.solved || showLocked;
 
             return <Node
-                key={chal.id} unlocked={unlocked} hidden={!isEdit && chal.hidden}
+                key={chal.id} unlocked={unlocked} hidden={!(isEdit || showLocked) && chal.hidden}
                 done={!isEdit && chal.solved}
 
                 linksR={linksR} linksL={linksL}
@@ -114,10 +114,10 @@ const CampaignChallenges = ({ challenges, showEditor, isEdit }) => {
                 isEdit={isEdit} toggleLink={toggleLink(chal)}
                 points={chal.score}
 
-                url={(isEdit || unlocked) ? "/campaign/" + challenges.id + "/challenge/" + chal.id
+                url={(isEdit || unlocked || showLocked) ? "/campaign/" + challenges.id + "/challenge/" + chal.id
                     + (isEdit ? "#edit" : "") : null}
 
-                name={(chal.hidden && !isEdit) ? <FaEyeSlash /> : !unlocked ? <FaLock /> : chal.name}
+                name={(chal.hidden && !(isEdit || showLocked)) ? <FaEyeSlash /> : !unlocked ? <FaLock /> : chal.name}
             />;
         })}</Row>
     );


### PR DESCRIPTION
This button enables admins to view all challenges, even if locked, for easier access during a live CTF. The preference is per-browser and will stay as set until the user clears their localStorage.